### PR TITLE
Remove quote character from Content Toggle wrap attributes

### DIFF
--- a/src/blocks/content-toggle/block.php
+++ b/src/blocks/content-toggle/block.php
@@ -78,7 +78,7 @@ function ub_render_content_toggle_panel_block( $attributes, $content, $block_obj
 											'"><span class="' . $classNamePrefix . '-accordion-state-indicator ' . $icon_class .
 											( $should_collapsed ? '' : ' open' ) . '"></span>
                     </div>' ) .
-			'</div><div role="region" '. 'aria-expanded="'. (json_encode(! $should_collapsed)) .'" class="' . $classNamePrefix . '-accordion-content-wrap' .
+			'</div><div role="region" aria-expanded="'. (json_encode(! $should_collapsed)) .'" class="' . $classNamePrefix . '-accordion-content-wrap' .
 			( $should_collapsed ? ' ub-hide' : '' ) . '" id="ub-content-toggle-panel-' . $index . '-' . $parentID . '">' . $content
 			. '</div></div>';
 }

--- a/src/blocks/content-toggle/block.php
+++ b/src/blocks/content-toggle/block.php
@@ -71,7 +71,7 @@ function ub_render_content_toggle_panel_block( $attributes, $content, $block_obj
 			. ( $parentID === '' ? ' style="border-color: ' . $theme . ';"' : '' ) . '>
                 <div class="' . $classNamePrefix . '-accordion-title-wrap"'
 			. ( $parentID === '' ? ' style="background-color: ' . $theme . ';"' : '' ) . ( $preventCollapse ? ' aria-disabled="true"' : '' )
-			.  '" aria-controls="ub-content-toggle-panel-' . $index . '-' . $parentID . '" tabindex="0">
+			.  ' aria-controls="ub-content-toggle-panel-' . $index . '-' . $parentID . '" tabindex="0">
                     <' . $titleTag . ' class="' . $classNamePrefix . '-accordion-title ub-content-toggle-title-' . $parentID . '"'
 			. ( $parentID === '' ? ' style="color:' . $titleColor . ';"' : '' ) . '>' . $panelTitle . '</' . $titleTag . '>' .
 			( $toggleIcon === 'none' ? '' : '<div class="' . $classNamePrefix . '-accordion-toggle-wrap ' . esc_attr( $toggleLocation ) .


### PR DESCRIPTION
An extra quotation mark prints in the title wrap element before `aria-controls`:

`<div class="wp-block-ub-content-toggle-accordion-title-wrap"" aria-controls="ub-content-toggle-panel-0-2560fff7-1bf0-49ec-938a-886b56a88179" tabindex="0">`

It also can add the extra quote character with `style="background-color: #ccc;"` or `aria-disabled="true"`.

This pull request removes the character plus unnecessary concatenation before `aria-expanded`.